### PR TITLE
refs #10 コンテンツグループごとに集計対象のディレクトリと最適化するページを指定でき、テンプレートを切り替える

### DIFF
--- a/classes/config.php
+++ b/classes/config.php
@@ -1,0 +1,14 @@
+<?php
+class LayoutOptimizerConfig {
+	const PLUGIN_ID              = 'layout-optimizer';
+	const CREDENTIAL_ACTION      = self::PLUGIN_ID . '-nonce-action';
+	const CREDENTIAL_NAME        = self::PLUGIN_ID . '-nonce-key';
+	const CREDENTIAL_VIEW_ACTION = self::PLUGIN_ID . '-view-nonce-action';
+	const CREDENTIAL_VIEW_NAME   = self::PLUGIN_ID . '-view-nonce-key';
+	const PLUGIN_DB_KEY          = self::PLUGIN_ID . '-data';
+	// config画面のslug
+	const CONFIG_MENU_SLUG = self::PLUGIN_ID . '-config';
+	const COMPLETE_CONFIG  = self::PLUGIN_ID . '-complete';
+	const ERROR_MESSAGE  = self::PLUGIN_ID . '-alert';
+	const CONTENTS_GROUP_COUNT = 10;
+}

--- a/classes/controllers/class.admin.php
+++ b/classes/controllers/class.admin.php
@@ -1,0 +1,98 @@
+<?php
+class LayoutOptimizerAdminController {
+
+	public function __construct() {
+		if ( is_admin() && is_user_logged_in() ) {
+			// メニュー追加
+			add_action( 'admin_menu', [ $this, 'set_plugin_menu' ] );
+			add_action( 'admin_notices', [ $this, 'flash_messages' ] );
+			add_action( 'admin_notices', [ $this, 'flash_alert' ] );
+			add_action( 'admin_init', [ $this, 'save_config' ] );
+			add_action( 'admin_init', [ $this, 'save_view_id' ] );
+		}
+	}
+
+	function set_plugin_menu() {
+		add_menu_page(
+			'レイアウト最適化',          /* ページタイトル*/
+			'レイアウト最適化',          /* メニュータイトル */
+			'manage_options',            /* 権限 */
+			LayoutOptimizerConfig::CONFIG_MENU_SLUG,      /* ページを開いたときのURL */
+			[ $this, 'show_config_form' ], /* メニューに紐づく画面を描画するcallback関数 */
+			'dashicons-format-gallery',  /* アイコン see: https://developer.wordpress.org/resource/dashicons/#awards */
+			99                           /* 表示位置のオフセット */
+		);
+	}
+
+	/** 設定画面の項目データベースに保存する */
+	function save_config() {
+		// nonceで設定したcredentialのチェック
+		if ( isset( $_POST[ LayoutOptimizerConfig::CREDENTIAL_NAME ] ) && $_POST[ LayoutOptimizerConfig::CREDENTIAL_NAME ] ) {
+			if ( check_admin_referer( LayoutOptimizerConfig::CREDENTIAL_ACTION, LayoutOptimizerConfig::CREDENTIAL_NAME ) ) {
+				// 保存処理
+				$data = [
+					'email'        => ! empty( $_POST['email'] ) ? $_POST['email'] : '',
+					'uid'          => ! empty( $_POST['uid'] ) ? $_POST['uid'] : '',
+					'client'       => ! empty( $_POST['client'] ) ? $_POST['client'] : '',
+					'expiry'       => ! empty( $_POST['expiry'] ) ? $_POST['expiry'] : '',
+					'access_token' => ! empty( $_POST['access_token'] ) ? $_POST['access_token'] : '',
+				];
+				update_option( LayoutOptimizerConfig::PLUGIN_DB_KEY, $data );
+				$completed_text = '連携が完了しました。';
+
+				// 保存が完了したら、WordPressの機構を使って、一度だけメッセージを表示する
+				set_transient( LayoutOptimizerConfig::COMPLETE_CONFIG, [ $completed_text ], 5 );
+
+				// 設定画面にリダイレクト
+				wp_safe_redirect( menu_page_url( LayoutOptimizerConfig::CONFIG_MENU_SLUG, false ) );
+			}
+		}
+	}
+
+	function save_view_id() {
+		// nonceで設定したcredentialのチェック
+		if ( isset( $_POST[ LayoutOptimizerConfig::CREDENTIAL_VIEW_NAME ] ) && $_POST[ LayoutOptimizerConfig::CREDENTIAL_VIEW_NAME ] ) {
+			if ( check_admin_referer( LayoutOptimizerConfig::CREDENTIAL_VIEW_ACTION, LayoutOptimizerConfig::CREDENTIAL_VIEW_NAME ) ) {
+				// 保存処理
+				$data = LayoutOptimizerOption::find();
+				$data->options['view_id'] = ! empty( $_POST['view_id'] ) ? filter_input( INPUT_POST, "view_id", FILTER_VALIDATE_INT) : '';
+				$optimize_page = filter_input( INPUT_POST, "optimize_page", FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
+				$dir = filter_input( INPUT_POST, "dir", FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
+				$data->options["contents_group"] = [];
+				for ( $i = 0 ; $i<LayoutOptimizerConfig::CONTENTS_GROUP_COUNT; $i++ ) {
+					$contents_group = ["optimize_page" => $optimize_page[$i],
+									   "query" => [ "dir" => $dir[$i] ] ];
+					$data->options["contents_group"][] = $contents_group;
+				}
+				if ( $data->options['view_id'] === false ) {
+					$e = new WP_Error();
+					$e->add('error', "view_idは数値で入力してください");
+					set_transient( LayoutOptimizerConfig::ERROR_MESSAGE, $e->get_error_messages(), 5 );
+				}else {
+					$data->save();
+					$data->fetch_theme();
+					$data->change_theme();
+					$completed_text = 'view_idと集計対象ディレクトリの保存が完了しました。';
+					// 保存が完了したら、WordPressの機構を使って、一度だけメッセージを表示する
+					set_transient( LayoutOptimizerConfig::COMPLETE_CONFIG, [ $completed_text ], 5 );
+				}
+				// 設定画面にリダイレクト
+				wp_safe_redirect( menu_page_url( LayoutOptimizerConfig::CONFIG_MENU_SLUG, false ) );
+			}
+		}
+	}
+
+	function show_config_form() {
+		wp_enqueue_script( 'layout-optimizer', plugins_url( '/dist/main.js', __FILE__ ), array(), date( 'U' ) );
+		$data = LayoutOptimizerOption::find();
+		include __DIR__ . '/../../templates/config_form.php';
+	}
+	function flash_alert() {
+		$messages = get_transient( LayoutOptimizerConfig::ERROR_MESSAGE );
+		include __DIR__ . '/../../templates/flash_alert.php';
+	}
+	function flash_messages() {
+		$messages = get_transient( LayoutOptimizerConfig::COMPLETE_CONFIG );
+		include __DIR__ . '/../../templates/flash_messages.php';
+	}
+}

--- a/classes/models/class.option.php
+++ b/classes/models/class.option.php
@@ -1,0 +1,88 @@
+<?php
+class LayoutOptimizerOption {
+
+	public $options = [];
+	protected $http;
+
+	public function __construct( $options, $http = null ) {
+		$this->options = $options;
+		$this->http = $http ? $http : new WP_Http();
+	}
+	/**
+	 * Update with retained data
+	 * @return boolean
+	 */
+	public function save() {
+		return update_option( LayoutOptimizerConfig::PLUGIN_DB_KEY, $this->options );
+	}
+	/**
+	 * Return all forms
+	 * @return array $comment
+	 */
+	public static function find() {
+		$options = get_option( LayoutOptimizerConfig::PLUGIN_DB_KEY, [] );
+		return new LayoutOptimizerOption( $options );
+	}
+
+	public function delete() {
+		return delete_option( LayoutOptimizerConfig::PLUGIN_DB_KEY );
+	}
+
+	function build_query( $query ) {
+		$qstring = http_build_query($query);
+		if ( !empty($qstring) ) {
+			return "?". $qstring;
+		}
+		return "";
+	}
+	function fetch_theme() {
+		if ( ! $this->is_api_login() && ! empty( $this->options['view_id'] ) ) {
+			return false;
+		}
+		for ( $i = 0; $i < count($this->options["contents_group"]); $i++ ) {
+			$url      = getenv( 'LAYOUT_OPTIMIZER_API_URL' ) ? getenv( 'LAYOUT_OPTIMIZER_API_URL' ) : 'https://layout-optimizer.herokuapp.com/api/v1/themes/';
+			$response = $this->http->get(
+				$url . $this->options['view_id'] . $this->build_query($this->options["contents_group"][$i]["query"]),
+				[
+					'headers' => [
+						'uid'          => $this->options['uid'],
+						'client'       => $this->options['client'],
+						'expiry'       => $this->options['expiry'],
+						'access-token' => $this->options['access_token'],
+						'Content-Type' => 'application/json',
+					],
+					'timeout' => 10,
+				]
+			);
+			if ( is_wp_error( $response ) || 200 !== $response['response']['code'] ) {
+				return $response;
+			}
+			$res                      = json_decode( $response['body'], true );
+			$this->options["contents_group"][$i]["theme"] = $res['theme'];
+			$this->options["contents_group"][$i]['gini_coefficient'] = $res['gini_coefficient'];
+			$this->options["contents_group"][$i]['json']             = $res;
+			$this->options["contents_group"][$i]['last']             = time();
+		}
+		$this->save();
+	}
+	function change_theme() {
+		foreach ( $this->options["contents_group"] as $contents_group ) {
+			if ( ! empty( $contents_group['theme'] ) || empty( $contents_group['optimize_page'] ) ) {
+				$post_id = url_to_postid($contents_group['optimize_page']);
+				if ( $post_id == 0 ) {
+					continue;
+				}
+				if ( 'A' === $contents_group['theme'] ) {
+					update_post_meta($post_id, "_wp_page_template", "page-a.php");
+				} elseif ( 'B' === $contents_group['theme'] ) {
+					update_post_meta($post_id, "_wp_page_template", "page-b.php");
+				} else {
+					update_post_meta($post_id, "_wp_page_template", "page-c.php");
+				}
+			}
+		}
+	}
+	function is_api_login() {
+		return ! ( empty( $this->options['uid'] ) || empty( $this->options['client'] ) || empty( $this->options['expiry'] ) || empty( $this->options['access_token'] ) );
+	}
+}

--- a/layout-optimizer.php
+++ b/layout-optimizer.php
@@ -10,35 +10,42 @@
 */
 add_action( 'init', 'LayoutOptimizer::init' );
 class LayoutOptimizer {
-	const PLUGIN_ID              = 'layout-optimizer';
-	const CREDENTIAL_ACTION      = self::PLUGIN_ID . '-nonce-action';
-	const CREDENTIAL_NAME        = self::PLUGIN_ID . '-nonce-key';
-	const CREDENTIAL_VIEW_ACTION = self::PLUGIN_ID . '-view-nonce-action';
-	const CREDENTIAL_VIEW_NAME   = self::PLUGIN_ID . '-view-nonce-key';
-	const PLUGIN_DB_KEY          = self::PLUGIN_ID . '-data';
-	// config画面のslug
-	const CONFIG_MENU_SLUG = self::PLUGIN_ID . '-config';
-	const COMPLETE_CONFIG  = self::PLUGIN_ID . '-complete';
-	const ERROR_MESSAGE  = self::PLUGIN_ID . '-alert';
-	const CONTENTS_GROUP_COUNT = 10;
 
 	static function init() {
 		return new self();
 	}
 
-	function __construct() {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->_load_initialize_files();
 		if ( is_admin() && is_user_logged_in() ) {
-			// メニュー追加
-			add_action( 'admin_menu', [ $this, 'set_plugin_menu' ] );
-			add_action( 'admin_notices', [ $this, 'flash_messages' ] );
-			add_action( 'admin_notices', [ $this, 'flash_alert' ] );
-			add_action( 'admin_init', [ $this, 'save_config' ] );
-			add_action( 'admin_init', [ $this, 'save_view_id' ] );
+			new LayoutOptimizerAdminController();
 		}
-		add_action( 'my_hourly_event', [ $this, 'my_hourly_action' ] );
-		$this->my_activation();
-		// register_activation_hook( __FILE__, 'LayoutOptimizer::my_activation');
-		register_deactivation_hook( __FILE__, 'LayoutOptimizer::my_deactivation' );
+	 	add_action( 'my_hourly_event', [ $this, 'my_hourly_action' ] );
+	 	$this->my_activation();
+	 	register_deactivation_hook( __FILE__, 'LayoutOptimizer::my_deactivation' );
+	}
+	/**
+	 * プラグインがロード時に実行する処理.
+	 *
+	 * @return void
+	 */
+	public function _load_initialize_files() {
+		require_once plugin_dir_path( __FILE__ ) . 'classes/config.php';
+		$plugin_dir_path = plugin_dir_path( __FILE__ );
+		$includes        = array(
+			'/classes/abstract',
+			'/classes/controllers',
+			'/classes/models',
+			'/classes/services',
+		);
+		foreach ( $includes as $include ) {
+			foreach ( glob( $plugin_dir_path . $include . '/*.php' ) as $file ) {
+				require_once $file;
+			}
+		}
 	}
 	function my_activation() {
 		// イベントが未登録なら登録する
@@ -52,152 +59,11 @@ class LayoutOptimizer {
 		delete_option( self::PLUGIN_DB_KEY );
 		wp_clear_scheduled_hook( 'my_hourly_event' );
 	}
+
 	function my_hourly_action() {
-		$this->fetch_theme();
-		$this->change_theme();
-	}
-	function change_theme() {
-		$data = get_option( self::PLUGIN_DB_KEY );
-		foreach ( $data["contents_group"] as $contents_group ) {
-			if ( ! empty( $contents_group['theme'] ) || empty( $contents_group['optimize_page'] ) ) {
-				$post_id = url_to_postid($contents_group['optimize_page']);
-				if ( $post_id == 0 ) {
-					continue;
-				}
-				if ( 'A' === $contents_group['theme'] ) {
-					switch_theme( 'twentysixteen' );
-					update_post_meta($post_id, "_wp_page_template", "page-a.php");
-				} elseif ( 'B' === $contents_group['theme'] ) {
-					update_post_meta($post_id, "_wp_page_template", "page-b.php");
-				} else {
-					update_post_meta($post_id, "_wp_page_template", "page-c.php");
-				}
-			}
-		}
-	}
-	function is_api_login( $data ) {
-		return ! ( empty( $data['uid'] ) || empty( $data['client'] ) || empty( $data['expiry'] ) || empty( $data['access_token'] ) );
-	}
-	function build_query( $query ) {
-		$qstring = http_build_query($query);
-		if ( !empty($qstring) ) {
-			return "?". $qstring;
-		}
-		return "";
-	}
-	function fetch_theme() {
-		$data = get_option( self::PLUGIN_DB_KEY );
-		if ( ! $this->is_api_login( $data ) && ! empty( $data['view_id'] ) ) {
-			return false;
-		}
-		for ( $i = 0; $i < count($data["contents_group"]); $i++ ) {
-			$http     = new WP_Http();
-			$url      = getenv( 'LAYOUT_OPTIMIZER_API_URL' ) ? getenv( 'LAYOUT_OPTIMIZER_API_URL' ) : 'https://layout-optimizer.herokuapp.com/api/v1/themes/';
-			$response = $http->get(
-				$url . $data['view_id'] . $this->build_query($data["contents_group"][$i]["query"]),
-				[
-					'headers' => [
-						'uid'          => $data['uid'],
-						'client'       => $data['client'],
-						'expiry'       => $data['expiry'],
-						'access-token' => $data['access_token'],
-						'Content-Type' => 'application/json',
-					],
-					'timeout' => 10,
-				]
-			);
-			if ( is_wp_error( $response ) || 200 !== $response['response']['code'] ) {
-				return $response;
-			}
-			$res                      = json_decode( $response['body'], true );
-			$data["contents_group"][$i]["theme"] = $res['theme'];
-			$data["contents_group"][$i]['gini_coefficient'] = $res['gini_coefficient'];
-			$data["contents_group"][$i]['json']             = $res;
-			$data["contents_group"][$i]['last']             = time();
-		}
-		update_option( self::PLUGIN_DB_KEY, $data );
-	}
-
-	function set_plugin_menu() {
-		add_menu_page(
-			'レイアウト最適化',          /* ページタイトル*/
-			'レイアウト最適化',          /* メニュータイトル */
-			'manage_options',            /* 権限 */
-			self::CONFIG_MENU_SLUG,      /* ページを開いたときのURL */
-			[ $this, 'show_config_form' ], /* メニューに紐づく画面を描画するcallback関数 */
-			'dashicons-format-gallery',  /* アイコン see: https://developer.wordpress.org/resource/dashicons/#awards */
-			99                           /* 表示位置のオフセット */
-		);
-	}
-	/** 設定画面の項目データベースに保存する */
-	function save_config() {
-		// nonceで設定したcredentialのチェック
-		if ( isset( $_POST[ self::CREDENTIAL_NAME ] ) && $_POST[ self::CREDENTIAL_NAME ] ) {
-			if ( check_admin_referer( self::CREDENTIAL_ACTION, self::CREDENTIAL_NAME ) ) {
-				// 保存処理
-				$data = [
-					'email'        => ! empty( $_POST['email'] ) ? $_POST['email'] : '',
-					'uid'          => ! empty( $_POST['uid'] ) ? $_POST['uid'] : '',
-					'client'       => ! empty( $_POST['client'] ) ? $_POST['client'] : '',
-					'expiry'       => ! empty( $_POST['expiry'] ) ? $_POST['expiry'] : '',
-					'access_token' => ! empty( $_POST['access_token'] ) ? $_POST['access_token'] : '',
-				];
-				update_option( self::PLUGIN_DB_KEY, $data );
-				$completed_text = '連携が完了しました。';
-
-				// 保存が完了したら、WordPressの機構を使って、一度だけメッセージを表示する
-				set_transient( self::COMPLETE_CONFIG, [ $completed_text ], 5 );
-
-				// 設定画面にリダイレクト
-				wp_safe_redirect( menu_page_url( self::CONFIG_MENU_SLUG, false ) );
-			}
-		}
-	}
-	function save_view_id() {
-		// nonceで設定したcredentialのチェック
-		if ( isset( $_POST[ self::CREDENTIAL_VIEW_NAME ] ) && $_POST[ self::CREDENTIAL_VIEW_NAME ] ) {
-			if ( check_admin_referer( self::CREDENTIAL_VIEW_ACTION, self::CREDENTIAL_VIEW_NAME ) ) {
-				// 保存処理
-				$data            = get_option( self::PLUGIN_DB_KEY );
-				$data['view_id'] = ! empty( $_POST['view_id'] ) ? filter_input( INPUT_POST, "view_id", FILTER_VALIDATE_INT) : '';
-				$optimize_page = filter_input( INPUT_POST, "optimize_page", FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
-				$dir = filter_input( INPUT_POST, "dir", FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
-				$data["contents_group"] = [];
-				for ( $i = 0 ; $i<self::CONTENTS_GROUP_COUNT; $i++ ) {
-					$contents_group = ["optimize_page" => $optimize_page[$i],
-									   "query" => [ "dir" => $dir[$i] ] ];
-					$data["contents_group"][] = $contents_group;
-				}
-				if ( $data['view_id'] === false ) {
-					$e = new WP_Error();
-					$e->add('error', "view_idは数値で入力してください");
-					set_transient( self::ERROR_MESSAGE, $e->get_error_messages(), 5 );
-				}else {
-					update_option( self::PLUGIN_DB_KEY, $data );
-					$this->fetch_theme();
-					$this->change_theme();
-					$completed_text = 'view_idと集計対象ディレクトリの保存が完了しました。';
-					// 保存が完了したら、WordPressの機構を使って、一度だけメッセージを表示する
-					set_transient( self::COMPLETE_CONFIG, [ $completed_text ], 5 );
-				}
-				// 設定画面にリダイレクト
-				wp_safe_redirect( menu_page_url( self::CONFIG_MENU_SLUG, false ) );
-			}
-		}
-	}
-
-	function show_config_form() {
-		wp_enqueue_script( 'layout-optimizer', plugins_url( '/dist/main.js', __FILE__ ), array(), date( 'U' ) );
-		$data = get_option( self::PLUGIN_DB_KEY );
-		include __DIR__ . '/templates/config_form.php';
-	}
-	function flash_alert() {
-		$messages = get_transient( self::ERROR_MESSAGE );
-		include __DIR__ . '/templates/flash_alert.php';
-	}
-	function flash_messages() {
-		$messages = get_transient( self::COMPLETE_CONFIG );
-		include __DIR__ . '/templates/flash_messages.php';
+		$data = LayoutOptimizerOption::find();
+		$data->fetch_theme();
+		$data->change_theme();
 	}
 }
 

--- a/templates/config_form.php
+++ b/templates/config_form.php
@@ -1,12 +1,12 @@
 <div class="wrap">
 	 <h1>Google Analyticsの設定</h1>
-        <?php if ( $this->is_api_login($data) && !empty($data['email']) ) { ?>
-        <p><?php echo esc_html($data['email']); ?>でログイン中 <input type='button' value='連携解除' class='signout button button-primary button-large'></p>
+        <?php if ( $data->is_api_login() && !empty($data->options['email']) ) { ?>
+        <p><?php echo esc_html($data->options['email']); ?>でログイン中 <input type='button' value='連携解除' class='signout button button-primary button-large'></p>
         <?php }else { ?>
         <p><input type='button' value='ログイン' class='signin button button-primary button-large'></p>
         <?php } ?>
         <form action="" method='post' id="my-submenu-form">
-            <?php wp_nonce_field(self::CREDENTIAL_ACTION, self::CREDENTIAL_NAME) ?>
+            <?php wp_nonce_field(LayoutOptimizerConfig::CREDENTIAL_ACTION, LayoutOptimizerConfig::CREDENTIAL_NAME) ?>
             <p>
               <input type="hidden" name="email" value=""/>
               <input type="hidden" name="uid" value=""/>
@@ -15,28 +15,28 @@
               <input type="hidden" name="access_token" value=""/>
             </p>
         </form>
-        <?php if ( $this->is_api_login($data) ) { ?>
-        <form action="" method='post' id="view-id-form">
-            <?php wp_nonce_field(self::CREDENTIAL_VIEW_ACTION, self::CREDENTIAL_VIEW_NAME) ?>
+        <?php if ( $data->is_api_login() ) { ?>
+        <form action="#" method='post' id="view-id-form">
+            <?php wp_nonce_field(LayoutOptimizerConfig::CREDENTIAL_VIEW_ACTION, LayoutOptimizerConfig::CREDENTIAL_VIEW_NAME) ?>
 			<ul>
             <li>
               <label for="view_id">GoogleAnalyticsのview_id:</label>
-              <input type="text" name="view_id" value="<?= esc_attr(!empty($data["view_id"]) ? $data["view_id"]: ""); ?>"/>
+              <input type="text" name="view_id" value="<?= esc_attr(!empty($data->options["view_id"]) ? $data->options["view_id"]: ""); ?>"/>
             </li>
-			<?php for ( $layout_optimizer_i = 0; $layout_optimizer_i < self::CONTENTS_GROUP_COUNT; $layout_optimizer_i++ ) { ?>
+			<?php for ( $layout_optimizer_i = 0; $layout_optimizer_i < LayoutOptimizerConfig::CONTENTS_GROUP_COUNT; $layout_optimizer_i++ ) { ?>
             <li>
               <label for="optimize_page">最適化するページ:</label>
-              <input type="text" name="optimize_page[]" value="<?= esc_attr(!empty($data["contents_group"][$layout_optimizer_i]["optimize_page"]) ? $data["contents_group"][$layout_optimizer_i]["optimize_page"]: ""); ?>"/>
+              <input type="text" name="optimize_page[]" value="<?= esc_attr(!empty($data->options["contents_group"][$layout_optimizer_i]["optimize_page"]) ? $data->options["contents_group"][$layout_optimizer_i]["optimize_page"]: ""); ?>"/>
               <label for="dir">集計対象のディレクトリ:</label>
-              <input type="text" name="dir[]" value="<?= esc_attr(!empty($data["contents_group"][$layout_optimizer_i]["query"]["dir"]) ? $data["contents_group"][$layout_optimizer_i]["query"]["dir"]: ""); ?>"/>
+              <input type="text" name="dir[]" value="<?= esc_attr(!empty($data->options["contents_group"][$layout_optimizer_i]["query"]["dir"]) ? $data->options["contents_group"][$layout_optimizer_i]["query"]["dir"]: ""); ?>"/>
             </li>
 			<?php } ?>
 			</ul>
             <p><input type='submit' value='登録' class='view_id button button-primary button-large' /></p>
         </form>
-            <?php if ( !empty($data["contents_group"]) ) { ?>
+            <?php if ( !empty($data->options["contents_group"]) ) { ?>
             <h2>APIの取得結果</h2>
-            	<?php foreach ( $data["contents_group"] as $layout_optimizer_content_group ) { ?>
+            	<?php foreach ( $data->options["contents_group"] as $layout_optimizer_content_group ) { ?>
             		<p>theme: <?= $layout_optimizer_content_group["theme"]; ?></p>
             		<p>gini: <?= $layout_optimizer_content_group["gini_coefficient"]; ?></p>
             		<p>json: <?= print_r($layout_optimizer_content_group["json"]); ?></p>

--- a/tests/classes/models/test-class.option.php
+++ b/tests/classes/models/test-class.option.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Class LayoutOptimizerOptionsTest
+ *
+ * @package Layout_Optimizer
+ */
+
+class LayoutOptimizerOptionTest extends WP_UnitTestCase {
+	/**
+	 * @test
+	 */
+	public function is_api_loginはログインしていない場合falseを返す() {
+		$data = new LayoutOptimizerOption([]);
+		// Replace this with some actual testing code.
+		$this->assertFalse($data->is_api_login());
+	}
+
+	/**
+	 * @test
+	 */
+	public function is_api_loginはログインしている場合場合trueを返す() {
+		$data = new LayoutOptimizerOption(["uid" => "1", "client"=>"hoge", "expiry" => 123, "access_token" =>"123abc"]);
+		// Replace this with some actual testing code.
+		$this->assertTrue($data->is_api_login());
+	}
+
+	/**
+	 * @test
+	 */
+	public function build_queryはquerystringを組み立てる() {
+		$data = new LayoutOptimizerOption([]);
+		// Replace this with some actual testing code.
+		$this->assertEquals("?hoge=hoge&fuga=%2Ffuga", $data->build_query(["hoge" => "hoge", "fuga" => "/fuga"]));
+	}
+
+	/**
+	 * @test
+	 */
+	public function build_queryは引数がから配列の場合空文字を返す() {
+		$data = new LayoutOptimizerOption([]);
+		// Replace this with some actual testing code.
+		$this->assertEquals("", $data->build_query([]));
+	}
+
+	/**
+	 * @test
+	 */
+	public function APIの結果をもとに固定ページのテンプレートを切り替える() {
+		$post_ids = [];
+		$post_ids [] = $this->factory()->post->create(["post_type"=>"page"]);
+		$post_ids [] = $this->factory()->post->create(["post_type"=>"page"]);
+		$post_ids [] = $this->factory()->post->create(["post_type"=>"page"]);
+
+		$option = [
+			"contents_group" => [
+				[
+					"theme" => "A",
+					"optimize_page" => get_permalink($post_ids[0]),
+				],
+				[
+					"theme" => "B",
+					"optimize_page" => get_permalink($post_ids[1]),
+				],
+				[
+					"theme" => "C",
+					"optimize_page" => get_permalink($post_ids[2]),
+				]
+			]
+		];
+		$data = new LayoutOptimizerOption($option);
+		$data->change_theme();
+		$this->assertEquals("page-a.php", get_post( $post_ids[0] )->page_template);
+		$this->assertEquals("page-b.php", get_post( $post_ids[1] )->page_template);
+		$this->assertEquals("page-c.php", get_post( $post_ids[2] )->page_template);
+	}
+
+	/**
+	 * @test
+	 */
+	public function fetch_themeはコンテンツグループごとにAPIにアクセスしてoptionに保存する() {
+		$stub = $this->createMock(WP_Http::class);
+		$stub->method("get")->willReturn([
+			"response" =>[
+				"code" => 200
+			],
+			"body" => json_encode([
+				"theme" => "A",
+				"gini_coefficient" => "0.77777",
+				"pages" => [
+					["page" => "/hoge", "pv" => 100],
+					["page" => "/fuga", "pv" => 1],
+				]
+			])
+		]);
+
+		$data = new LayoutOptimizerOption(["view_id" => 1234,
+										   "uid" => "1234",
+										   "client" => "test",
+										   "expiry" => "12345678",
+										   "access_token" => "token",
+										   "contents_group" => [
+											   [
+												   "query" =>  ["dir" => "/"]
+											   ],
+											   [
+												   "query" =>  ["dir" => "/"]
+											   ]
+										   ]
+		], $stub);
+		$data->fetch_theme();
+		$this->assertEquals("A", $data->options["contents_group"][0]["theme"]);
+		$this->assertEquals("A", $data->options["contents_group"][1]["theme"]);
+	}
+
+	/**
+	 * @test
+	 */
+	public function fetch_themeはAPIサーバーと連携していない場合何もしない() {
+		$stub = $this->createMock(WP_Http::class);
+		$data = new LayoutOptimizerOption(["view_id" => 1234,
+										   "contents_group" => [
+											   [
+												   "query" =>  ["dir" => "/"]
+											   ],
+											   [
+												   "query" =>  ["dir" => "/"]
+											   ]
+										   ]
+		], $stub);
+		$this->assertFalse($data->fetch_theme());
+	}
+
+	/**
+	 * @test
+	 */
+	public function fetch_themeはview_idがない場合は何もしない() {
+		$stub = $this->createMock(WP_Http::class);
+		$data = new LayoutOptimizerOption(["view_id" => 1234,
+										   "contents_group" => [
+											   [
+												   "query" =>  ["dir" => "/"]
+											   ],
+											   [
+												   "query" =>  ["dir" => "/"]
+											   ]
+										   ]
+		], $stub);
+		$this->assertFalse($data->fetch_theme());
+	}
+
+	/**
+	 * @test
+	 */
+	public function fetch_themeはAPIがエラーになった場合それ以降を取得しない() {
+		$stub = $this->createMock(WP_Http::class);
+		$stub->method("get")->willReturn([
+			"response" =>[
+				"code" => 500
+			],
+			"body" => json_encode([
+				"theme" => "A",
+				"gini_coefficient" => "0.77777",
+				"pages" => [
+					["page" => "/hoge", "pv" => 100],
+					["page" => "/fuga", "pv" => 1],
+				]
+			])
+		]);
+
+		$data = new LayoutOptimizerOption(["view_id" => 1234,
+										   "uid" => "1234",
+										   "client" => "test",
+										   "expiry" => "12345678",
+										   "access_token" => "token",
+										   "contents_group" => [
+											   [
+												   "query" =>  ["dir" => "/"]
+											   ],
+											   [
+												   "query" =>  ["dir" => "/"]
+											   ]
+										   ]
+		], $stub);
+		$response = $data->fetch_theme();
+		$this->assertEquals(500, $response["response"]["code"]);
+	}
+}

--- a/tests/test-layout-optimizer.php
+++ b/tests/test-layout-optimizer.php
@@ -10,22 +10,10 @@
  */
 class LayoutOptimizerTest extends WP_UnitTestCase {
 	/**
-	 * @test
+	 * A single example test.
 	 */
-	public function is_api_loginはログインしていない場合falseを返す() {
-		$data = [];
-		$plugin = new LayoutOptimizer();
+	public function test_sample() {
 		// Replace this with some actual testing code.
-		$this->assertFalse($plugin->is_api_login($data));
-	}
-
-	/**
-	 * @test
-	 */
-	public function is_api_loginはログインしている場合場合trueを返す() {
-		$data = ["uid" => "1", "client"=>"hoge", "expiry" => 123, "access_token" =>"123abc"];
-		$plugin = new LayoutOptimizer();
-		// Replace this with some actual testing code.
-		$this->assertTrue($plugin->is_api_login($data));
+		$this->assertTrue( true );
 	}
 }


### PR DESCRIPTION
Fixed #10
Fixed #14  
refs designrule/layout-optimizer#30

# コンテンツグループごとに値を設定できるように修正

言語別設定の項目は消した
[![Image from Gyazo](https://i.gyazo.com/09a007098631e839555a30d17edc8635.png)](https://gyazo.com/09a007098631e839555a30d17edc8635)

最初の案 [https://i.gyazo.com/8b0a68fece663cfad5be310a461b78dc.png)](https://gyazo.com/8b0a68fece663cfad5be310a461b78dc)

## 課題点
- [x] レイアウト変更対象のページのidを取得する方法がない

# 以前のバージョン
[![Image from Gyazo](https://i.gyazo.com/f20f5bc1bac62945a468849662c5f8c0.png)](https://gyazo.com/f20f5bc1bac62945a468849662c5f8c0)

集計対象のディレクトリのディレクトリを正規表現で指定します。
何も指定しない場合は、「/」が設定されます。