### PR TITLE
Fixed #26 composer installできるようにcomposer.jsonの項目を追加

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,8 @@
 {
+  "name": "designrule/layout-optimizer-plugin",
+  "description": "layout-optimizer-plugin optimizes your page",
+  "homepage": "https://designrule.jp",
+  "type": "wordpress-plugin",
   "require-dev": {
     "phpunit/phpunit": "7.*",
     "squizlabs/php_codesniffer": "3.*",


### PR DESCRIPTION
Fixed #26 
[WordPress のプラグインも composer に対応させて packagist に登録するといいよ！ - Toro\_Unit](https://torounit.com/blog/2016/07/29/2395/)
[jetpack/composer.json at master · Automattic/jetpack](https://github.com/Automattic/jetpack/blob/master/composer.json)
を参考に、composer.jsonに項目を追加しました。

masterに入れて試します（何度か微修正するかもしれません）