### PR TITLE
Fixed #29 jsのパスをlayout-optimzier-plugin/dist/main.jsに変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM wordpress
 
-RUN apt-get update && apt-get install -y zip
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 apt-get update && \
-apt-get install -y nodejs \
+apt-get install -y zip \
+ nodejs \
  less \
  wget \
  subversion \
- mysql-client && \
+ default-mysql-client && \
  rm -rf /var/lib/apt/lists/*
 
  

--- a/classes/controllers/class.admin.php
+++ b/classes/controllers/class.admin.php
@@ -82,7 +82,7 @@ class LayoutOptimizerAdminController {
 	}
 
 	function show_config_form() {
-		wp_enqueue_script( 'layout-optimizer', plugins_url( 'layout-optimizer/dist/main.js'), [], date( 'U' ) );
+		wp_enqueue_script( 'layout-optimizer', plugins_url( 'layout-optimizer-plugin/dist/main.js'), [], date( 'U' ) );
 		$data = LayoutOptimizerOption::find();
 		include __DIR__ . '/../../templates/config_form.php';
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - .:/var/www/html/wp-content/plugins/layout-optimizer
+      - .:/var/www/html/wp-content/plugins/layout-optimizer-plugin
       - for-testing:/tmp
     depends_on:
       - db

--- a/layout-optimizer.php
+++ b/layout-optimizer.php
@@ -3,7 +3,7 @@
 	Plugin Name: LayoutOptimizer
 	Plugin URI:
 	Description: レイアウトを最適化するプラグイン
-	Version: 0.0.3
+	Version: 0.0.4
 	Author: designrule
 	Author URI: https://github.com/designrule/layout-optimizer-plugin
 	License: UNLICENSED


### PR DESCRIPTION
リポジトリ名= パッケージ名=pluginのディレクトリ名となったため
jsのパスを
layout-optimzierから
layout-optimzier-pluginに変更しました。