### PR TITLE
Fixed #91 wp_googlenalytics.pvカラムをTEXT型からmediumint型に変更

### DIFF
--- a/classes/config.php
+++ b/classes/config.php
@@ -6,7 +6,7 @@ class LayoutOptimizerConfig {
 	const CREDENTIAL_VIEW_ACTION = self::PLUGIN_ID . '-view-nonce-action';
 	const CREDENTIAL_VIEW_NAME   = self::PLUGIN_ID . '-view-nonce-key';
 	const PLUGIN_DB_KEY          = self::PLUGIN_ID . '-data';
-	const PLUGIN_DB_VERSION      = 201908271240;
+	const PLUGIN_DB_VERSION      = 202004141349;
 	// config画面のslug
 	const CONFIG_MENU_SLUG = self::PLUGIN_ID . '-config';
 	const COMPLETE_CONFIG  = self::PLUGIN_ID . '-complete';

--- a/classes/models/class.googleanalytics.php
+++ b/classes/models/class.googleanalytics.php
@@ -23,7 +23,7 @@ class LayoutOptimizerGoogleAnalytics {
     id mediumint(9) NOT NULL AUTO_INCREMENT PRIMARY KEY,
     path text NOT NULL,
     post_id mediumint(9) NOT NULL,
-    pv text NOT NULL,
+    pv mediumint(9) NOT NULL,
     optimize_page_id mediumint(9) NOT NULL,
     KEY post_id_index(post_id)
   ) $charset_collate;";

--- a/layout-optimizer.php
+++ b/layout-optimizer.php
@@ -3,7 +3,7 @@
 	Plugin Name: LayoutOptimizer
 	Plugin URI:
 	Description: レイアウトを最適化するプラグイン
-	Version: 0.0.5
+	Version: 0.0.6
 	Author: designrule
 	Author URI: https://github.com/designrule/layout-optimizer-plugin
 	License: UNLICENSED


### PR DESCRIPTION
Fixed #91
pvカラムが文字列型で定義されているため、おすすめ順のが正しく出ないのを修正します。

