### PR TITLE
Fixed #40 bogoプラグインと組み合わせた時に、url_to_postidが不安定になるのを修正

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,339 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 	cp .env.sample .env
 	docker-compose build
     docker-compose up -d
-	docker-compose exec wordpress bash -c "cd /var/www/html/wp-content/plugins/my-plugin; composer install"
-	docker-compose exec wordpress bash -c "cd /var/www/html/wp-content/plugins/my-plugin; npm install"	
-	docker-compose exec wordpress bash -c "cd /var/www/html/wp-content/plugins/my-plugin; npx webpack --mode=development"	
+	docker-compose exec wordpress bash -c "cd /var/www/html/wp-content/plugins/layout-optimizer-plugin; composer install"
+	docker-compose exec wordpress bash -c "cd /var/www/html/wp-content/plugins/layout-optimizer-plugin; npm install"	
+	docker-compose exec wordpress bash -c "cd /var/www/html/wp-content/plugins/layout-optimizer-plugin; npx webpack --mode=development"	
 
 ### WordPressの設定
 
@@ -22,20 +22,20 @@
 localボリュームに永続化しているので、1回だけやればOK
 MySQLのrootパスワードは.envファイルで設定したMYSQL_ROOT_PASSWORDを指定する。
 
-    docker-compose exec wordpress bash -c "/var/www/html/wp-content/plugins/layout-optimizer/bin/install-wp-tests.sh wordpress_test root 'wordpress' db latest"
+    docker-compose exec wordpress bash -c "/var/www/html/wp-content/plugins/layout-optimizer-plugin/bin/install-wp-tests.sh wordpress_test root 'wordpress' db latest"
 
 
 ### PHPUnitの実行
 
-    docker-compose exec wordpress bash -c "cd /var/www/html/wp-content/plugins/my-plugin; vendor/bin/phpunit"
+    docker-compose exec wordpress bash -c "cd /var/www/html/wp-content/plugins/layout-optimizer-plugin; vendor/bin/phpunit"
 
 ### phpcsの実行
 
-    docker-compose exec wordpress bash -c "cd /var/www/html/wp-content/plugins/my-plugin; composer phpcs"
+    docker-compose exec wordpress bash -c "cd /var/www/html/wp-content/plugins/layout-optimizer-plugin; composer phpcs"
 
 ### phpcbf(自動フォーマット)の実行
 
-    docker-compose exec wordpress bash -c "cd /var/www/html/wp-content/plugins/my-plugin; composer phpcbf"
+    docker-compose exec wordpress bash -c "cd /var/www/html/wp-content/plugins/layout-optimizer-plugin; composer phpcbf"
 
 ### リリース方法
 

--- a/classes/controllers/class.admin.php
+++ b/classes/controllers/class.admin.php
@@ -55,12 +55,15 @@ class LayoutOptimizerAdminController {
 				// 保存処理
 				$data = LayoutOptimizerOption::find();
 				$data->options['view_id'] = ! empty( $_POST['view_id'] ) ? filter_input( INPUT_POST, "view_id", FILTER_VALIDATE_INT) : '';
+				$optimize_page_id = filter_input( INPUT_POST, "optimize_page_id", FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
 				$optimize_page = filter_input( INPUT_POST, "optimize_page", FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
 				$dir = filter_input( INPUT_POST, "dir", FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
 				$data->options["contents_group"] = [];
 				for ( $i = 0 ; $i<LayoutOptimizerConfig::CONTENTS_GROUP_COUNT; $i++ ) {
-					$contents_group = ["optimize_page" => $optimize_page[$i],
-									   "query" => [ "dir" => $dir[$i] ] ];
+					$contents_group = [
+						"optimize_page_id" => $optimize_page_id[$i],
+						"optimize_page" => $optimize_page[$i],
+						"query" => [ "dir" => $dir[$i] ] ];
 					$data->options["contents_group"][] = $contents_group;
 				}
 				if ( $data->options['view_id'] === false ) {

--- a/classes/models/class.option.php
+++ b/classes/models/class.option.php
@@ -102,7 +102,7 @@ class LayoutOptimizerOption {
 	function is_api_login() {
 		return ! ( empty( $this->options['uid'] ) || empty( $this->options['client'] ) || empty( $this->options['expiry'] ) || empty( $this->options['access_token'] ) );
 	}
-	function url_to_postid($url) {
+	function url_to_postid( $url ) {
 		// First, check to see if there is a 'p=N' or 'page_id=N' to match against.
 		if ( preg_match( '#[?&](p|page_id|attachment_id)=(\d+)#', $url, $values ) ) {
 			$id = absint( $values[2] );
@@ -111,7 +111,7 @@ class LayoutOptimizerOption {
 			}
 		}
 		$parsed = parse_url($url);
-		if($parsed == false) {
+		if ( $parsed == false ) {
 			return 0;
 		}
 		if ( preg_match( '#(\d+)$#', $parsed["path"], $values ) ) {

--- a/classes/models/class.option.php
+++ b/classes/models/class.option.php
@@ -71,7 +71,7 @@ class LayoutOptimizerOption {
 			}
 			for ( $j = 0; $j < count($res["pages"]); $j++ ) {
 				$res["pages"][$j]["post_id"] = $this->url_to_postid($res["pages"][$j]["path"]);
-				if ( isset($this->options["contents_group"][$i]["optimize_page"]) ) {
+				if ( isset($this->options["contents_group"][$i]["optimize_page_id"]) ) {
 					$res["pages"][$j]["optimize_page_id"] = $this->options["contents_group"][$i]["optimize_page_id"];
 				}else {
 					$res["pages"][$j]["optimize_page_id"] = $this->url_to_postid($this->options["contents_group"][$i]["optimize_page"]);

--- a/classes/models/class.option.php
+++ b/classes/models/class.option.php
@@ -71,7 +71,11 @@ class LayoutOptimizerOption {
 			}
 			for ( $j = 0; $j < count($res["pages"]); $j++ ) {
 				$res["pages"][$j]["post_id"] = $this->url_to_postid($res["pages"][$j]["path"]);
-				$res["pages"][$j]["optimize_page_id"] = $this->url_to_postid($this->options["contents_group"][$i]["optimize_page"]);
+				if ( isset($this->options["contents_group"][$i]["optimize_page"]) ) {
+					$res["pages"][$j]["optimize_page_id"] = $this->options["contents_group"][$i]["optimize_page_id"];
+				}else {
+					$res["pages"][$j]["optimize_page_id"] = $this->url_to_postid($this->options["contents_group"][$i]["optimize_page"]);
+				}
 			}
 			$pv_list = array_merge($pv_list, $res["pages"]);
 			$this->options["contents_group"][$i]["theme"] = $res['theme'];
@@ -85,7 +89,12 @@ class LayoutOptimizerOption {
 	function change_theme() {
 		foreach ( $this->options["contents_group"] as $contents_group ) {
 			if ( ! empty( $contents_group['theme'] ) || empty( $contents_group['optimize_page'] ) ) {
-				$post_id = $this->url_to_postid($contents_group['optimize_page']);
+				$post_id = 0;
+				if ( isset($contents_group['optimize_page_id']) ) {
+					$post_id = $contents_group['optimize_page_id'];
+				}else {
+					$post_id = $this->url_to_postid($contents_group['optimize_page']);
+				}
 				if ( $post_id == 0 ) {
 					continue;
 				}

--- a/classes/models/class.option.php
+++ b/classes/models/class.option.php
@@ -71,7 +71,7 @@ class LayoutOptimizerOption {
 			}
 			for ( $j = 0; $j < count($res["pages"]); $j++ ) {
 				$res["pages"][$j]["post_id"] = $this->url_to_postid($res["pages"][$j]["path"]);
-				if ( isset($this->options["contents_group"][$i]["optimize_page_id"]) ) {
+				if ( !empty($this->options["contents_group"][$i]["optimize_page_id"]) ) {
 					$res["pages"][$j]["optimize_page_id"] = $this->options["contents_group"][$i]["optimize_page_id"];
 				}else {
 					$res["pages"][$j]["optimize_page_id"] = $this->url_to_postid($this->options["contents_group"][$i]["optimize_page"]);
@@ -90,7 +90,7 @@ class LayoutOptimizerOption {
 		foreach ( $this->options["contents_group"] as $contents_group ) {
 			if ( ! empty( $contents_group['theme'] ) || empty( $contents_group['optimize_page'] ) ) {
 				$post_id = 0;
-				if ( isset($contents_group['optimize_page_id']) ) {
+				if ( !empty($contents_group['optimize_page_id']) ) {
 					$post_id = $contents_group['optimize_page_id'];
 				}else {
 					$post_id = $this->url_to_postid($contents_group['optimize_page']);

--- a/classes/models/class.option.php
+++ b/classes/models/class.option.php
@@ -70,8 +70,8 @@ class LayoutOptimizerOption {
 				];
 			}
 			for ( $j = 0; $j < count($res["pages"]); $j++ ) {
-				$res["pages"][$j]["post_id"] = url_to_postid($res["pages"][$j]["path"]);
-				$res["pages"][$j]["optimize_page_id"] = url_to_postid($this->options["contents_group"][$i]["optimize_page"]);
+				$res["pages"][$j]["post_id"] = $this->url_to_postid($res["pages"][$j]["path"]);
+				$res["pages"][$j]["optimize_page_id"] = $this->url_to_postid($this->options["contents_group"][$i]["optimize_page"]);
 			}
 			$pv_list = array_merge($pv_list, $res["pages"]);
 			$this->options["contents_group"][$i]["theme"] = $res['theme'];
@@ -85,7 +85,7 @@ class LayoutOptimizerOption {
 	function change_theme() {
 		foreach ( $this->options["contents_group"] as $contents_group ) {
 			if ( ! empty( $contents_group['theme'] ) || empty( $contents_group['optimize_page'] ) ) {
-				$post_id = url_to_postid($contents_group['optimize_page']);
+				$post_id = $this->url_to_postid($contents_group['optimize_page']);
 				if ( $post_id == 0 ) {
 					continue;
 				}
@@ -101,5 +101,25 @@ class LayoutOptimizerOption {
 	}
 	function is_api_login() {
 		return ! ( empty( $this->options['uid'] ) || empty( $this->options['client'] ) || empty( $this->options['expiry'] ) || empty( $this->options['access_token'] ) );
+	}
+	function url_to_postid($url) {
+		// First, check to see if there is a 'p=N' or 'page_id=N' to match against.
+		if ( preg_match( '#[?&](p|page_id|attachment_id)=(\d+)#', $url, $values ) ) {
+			$id = absint( $values[2] );
+			if ( $id ) {
+				return $id;
+			}
+		}
+		$parsed = parse_url($url);
+		if($parsed == false) {
+			return 0;
+		}
+		if ( preg_match( '#(\d+)$#', $parsed["path"], $values ) ) {
+			$id = absint( $values[1] );
+			if ( $id ) {
+				return $id;
+			}
+		}
+		return 0;
 	}
 }

--- a/layout-optimizer.php
+++ b/layout-optimizer.php
@@ -3,10 +3,10 @@
 	Plugin Name: LayoutOptimizer
 	Plugin URI:
 	Description: レイアウトを最適化するプラグイン
-	Version: 0.0.7
+	Version: 0.0.8
 	Author: designrule
 	Author URI: https://github.com/designrule/layout-optimizer-plugin
-	License: UNLICENSED
+	License: GPL2
 */
 add_action( 'init', 'LayoutOptimizer::init' );
 class LayoutOptimizer {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2356,27 +2356,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
-      "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
-      "requires": {
-        "debug": "^3.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        }
-      }
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.12.1.tgz",
+      "integrity": "sha512-tmRv0AVuR7ZyouUHLeNSiO6pqulF7dYa3s19c6t+wz9LD69/uSzdMxJ2S91nTI9U3rt/IldxpzMOFejp6f0hjg=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -2444,8 +2426,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2463,13 +2444,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2482,18 +2461,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2596,8 +2572,7 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2607,7 +2582,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2620,20 +2594,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2650,7 +2621,6 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -2706,8 +2676,7 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -2732,8 +2701,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2743,7 +2711,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2812,8 +2779,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2843,7 +2809,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2861,7 +2826,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2900,13 +2864,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -3179,9 +3141,9 @@
       }
     },
     "http-proxy": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
-      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "requires": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -3614,9 +3576,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "loglevel": {
       "version": "1.6.8",

--- a/templates/config_form.php
+++ b/templates/config_form.php
@@ -25,6 +25,8 @@
             </li>
 			<?php for ( $layout_optimizer_i = 0; $layout_optimizer_i < LayoutOptimizerConfig::CONTENTS_GROUP_COUNT; $layout_optimizer_i++ ) { ?>
             <li>
+              <label for="optimize_page">最適化するページID:</label>
+              <input type="text" name="optimize_page_id[]" value="<?= esc_attr(!empty($data->options["contents_group"][$layout_optimizer_i]["optimize_page_id"]) ? $data->options["contents_group"][$layout_optimizer_i]["optimize_page_id"]: ""); ?>"/>
               <label for="optimize_page">最適化するページ:</label>
               <input type="text" name="optimize_page[]" value="<?= esc_attr(!empty($data->options["contents_group"][$layout_optimizer_i]["optimize_page"]) ? $data->options["contents_group"][$layout_optimizer_i]["optimize_page"]: ""); ?>"/>
               <label for="dir">集計対象のディレクトリ:</label>

--- a/tests/classes/models/test-class.option.php
+++ b/tests/classes/models/test-class.option.php
@@ -192,4 +192,18 @@ class LayoutOptimizerOptionTest extends WP_UnitTestCase {
 		$response = $data->fetch_theme();
 		$this->assertEquals(500, $response["response"]["code"]);
 	}
+	/**
+	 * @test
+	 */
+	public function url_to_postidはURLからpostidが取得できれば返す() {
+		$data = new LayoutOptimizerOption([]);
+		$this->assertEquals(12345, $data->url_to_postid("/sample/12345"));
+		$this->assertEquals(12345, $data->url_to_postid("/page_id=12345"));
+	}
+
+	public function url_to_postidはURLからpostidが取得できれば0を返す() {
+		$data = new LayoutOptimizerOption([]);
+		$this->assertEquals(0, $data->url_to_postid("/"));
+		$this->assertEquals(0, $data->url_to_postid(""));
+	}
 }

--- a/tests/classes/models/test-class.option.php
+++ b/tests/classes/models/test-class.option.php
@@ -198,7 +198,8 @@ class LayoutOptimizerOptionTest extends WP_UnitTestCase {
 	public function url_to_postidはURLからpostidが取得できれば返す() {
 		$data = new LayoutOptimizerOption([]);
 		$this->assertEquals(12345, $data->url_to_postid("/sample/12345"));
-		$this->assertEquals(12345, $data->url_to_postid("/page_id=12345"));
+		$this->assertEquals(12345, $data->url_to_postid("/?page_id=12345"));
+		$this->assertEquals(12345, $data->url_to_postid("/?p=12345"));
 	}
 
 	public function url_to_postidはURLからpostidが取得できれば0を返す() {


### PR DESCRIPTION
Fixed #40 

# 修正内容
1. URLから正規表現でpost_idを取得する修正
- パスの末尾の数字列はpost_idとみなす
  -（レイアウト最適化プラグインを使う上での前提条件とする）
  - かなり強い前提
  - 動作確認に不便なので、クエリパラメータ(p,page_id)がある場合は、そこから抽出する（wordpress本体のurl_to_post_idのロジックを使っている）

2. 設定画面に、最適化するページのpost_idを指定する欄を追加

[![Image from Gyazo](https://i.gyazo.com/7e71fdece0b2a06a18b20c3704e9da4a.png)](https://gyazo.com/7e71fdece0b2a06a18b20c3704e9da4a)
