### PR TITLE
Fixed #44 設定画面で最適化するページのパスを指定する欄を削除

### DIFF
--- a/classes/controllers/class.admin.php
+++ b/classes/controllers/class.admin.php
@@ -56,13 +56,11 @@ class LayoutOptimizerAdminController {
 				$data = LayoutOptimizerOption::find();
 				$data->options['view_id'] = ! empty( $_POST['view_id'] ) ? filter_input( INPUT_POST, "view_id", FILTER_VALIDATE_INT) : '';
 				$optimize_page_id = filter_input( INPUT_POST, "optimize_page_id", FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
-				$optimize_page = filter_input( INPUT_POST, "optimize_page", FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
 				$dir = filter_input( INPUT_POST, "dir", FILTER_DEFAULT, FILTER_REQUIRE_ARRAY);
 				$data->options["contents_group"] = [];
 				for ( $i = 0 ; $i<LayoutOptimizerConfig::CONTENTS_GROUP_COUNT; $i++ ) {
 					$contents_group = [
 						"optimize_page_id" => $optimize_page_id[$i],
-						"optimize_page" => $optimize_page[$i],
 						"query" => [ "dir" => $dir[$i] ] ];
 					$data->options["contents_group"][] = $contents_group;
 				}

--- a/classes/models/class.googleanalytics.php
+++ b/classes/models/class.googleanalytics.php
@@ -4,7 +4,7 @@ class LayoutOptimizerGoogleAnalytics {
 	protected $post_id;
 	protected $path;
 	protected $pv;
-	protected $optimize_page;
+	protected $optimize_page_id;
 
 	public function __construct( $id, $post_id, $path, $pv, $optimize_page_id ) {
 		$this->id = $id;

--- a/classes/models/class.option.php
+++ b/classes/models/class.option.php
@@ -71,11 +71,7 @@ class LayoutOptimizerOption {
 			}
 			for ( $j = 0; $j < count($res["pages"]); $j++ ) {
 				$res["pages"][$j]["post_id"] = $this->url_to_postid($res["pages"][$j]["path"]);
-				if ( !empty($this->options["contents_group"][$i]["optimize_page_id"]) ) {
-					$res["pages"][$j]["optimize_page_id"] = $this->options["contents_group"][$i]["optimize_page_id"];
-				}else {
-					$res["pages"][$j]["optimize_page_id"] = $this->url_to_postid($this->options["contents_group"][$i]["optimize_page"]);
-				}
+				$res["pages"][$j]["optimize_page_id"] = $this->options["contents_group"][$i]["optimize_page_id"];
 			}
 			$pv_list = array_merge($pv_list, $res["pages"]);
 			$this->options["contents_group"][$i]["theme"] = $res['theme'];
@@ -89,13 +85,8 @@ class LayoutOptimizerOption {
 	function change_theme() {
 		foreach ( $this->options["contents_group"] as $contents_group ) {
 			if ( ! empty( $contents_group['theme'] ) || empty( $contents_group['optimize_page'] ) ) {
-				$post_id = 0;
-				if ( !empty($contents_group['optimize_page_id']) ) {
-					$post_id = $contents_group['optimize_page_id'];
-				}else {
-					$post_id = $this->url_to_postid($contents_group['optimize_page']);
-				}
-				if ( $post_id == 0 ) {
+				$post_id = $contents_group['optimize_page_id'];
+				if ( empty($post_id) ) {
 					continue;
 				}
 				if ( 'A' === $contents_group['theme'] ) {

--- a/layout-optimizer.php
+++ b/layout-optimizer.php
@@ -3,7 +3,7 @@
 	Plugin Name: LayoutOptimizer
 	Plugin URI:
 	Description: レイアウトを最適化するプラグイン
-	Version: 0.0.8
+	Version: 0.0.9
 	Author: designrule
 	Author URI: https://github.com/designrule/layout-optimizer-plugin
 	License: GPL2

--- a/templates/config_form.php
+++ b/templates/config_form.php
@@ -25,7 +25,7 @@
             </li>
 			<?php for ( $layout_optimizer_i = 0; $layout_optimizer_i < LayoutOptimizerConfig::CONTENTS_GROUP_COUNT; $layout_optimizer_i++ ) { ?>
             <li>
-              <label for="optimize_page">最適化するページID:</label>
+              <label for="optimize_page_id">最適化するページのpostid:</label>
               <input type="text" name="optimize_page_id[]" value="<?= esc_attr(!empty($data->options["contents_group"][$layout_optimizer_i]["optimize_page_id"]) ? $data->options["contents_group"][$layout_optimizer_i]["optimize_page_id"]: ""); ?>"/>
               <label for="dir">集計対象のディレクトリ:</label>
               <input type="text" name="dir[]" value="<?= esc_attr(!empty($data->options["contents_group"][$layout_optimizer_i]["query"]["dir"]) ? $data->options["contents_group"][$layout_optimizer_i]["query"]["dir"]: ""); ?>"/>

--- a/templates/config_form.php
+++ b/templates/config_form.php
@@ -27,8 +27,6 @@
             <li>
               <label for="optimize_page">最適化するページID:</label>
               <input type="text" name="optimize_page_id[]" value="<?= esc_attr(!empty($data->options["contents_group"][$layout_optimizer_i]["optimize_page_id"]) ? $data->options["contents_group"][$layout_optimizer_i]["optimize_page_id"]: ""); ?>"/>
-              <label for="optimize_page">最適化するページ:</label>
-              <input type="text" name="optimize_page[]" value="<?= esc_attr(!empty($data->options["contents_group"][$layout_optimizer_i]["optimize_page"]) ? $data->options["contents_group"][$layout_optimizer_i]["optimize_page"]: ""); ?>"/>
               <label for="dir">集計対象のディレクトリ:</label>
               <input type="text" name="dir[]" value="<?= esc_attr(!empty($data->options["contents_group"][$layout_optimizer_i]["query"]["dir"]) ? $data->options["contents_group"][$layout_optimizer_i]["query"]["dir"]: ""); ?>"/>
             </li>

--- a/tests/classes/models/test-class.option.php
+++ b/tests/classes/models/test-class.option.php
@@ -55,15 +55,15 @@ class LayoutOptimizerOptionTest extends WP_UnitTestCase {
 			"contents_group" => [
 				[
 					"theme" => "A",
-					"optimize_page" => get_permalink($post_ids[0]),
+					"optimize_page_id" => $post_ids[0],
 				],
 				[
 					"theme" => "B",
-					"optimize_page" => get_permalink($post_ids[1]),
+					"optimize_page_id" => $post_ids[1],
 				],
 				[
 					"theme" => "C",
-					"optimize_page" => get_permalink($post_ids[2]),
+					"optimize_page_id" => $post_ids[2],
 				]
 			]
 		];
@@ -101,11 +101,11 @@ class LayoutOptimizerOptionTest extends WP_UnitTestCase {
 										   "contents_group" => [
 											   [
 												   "query" =>  ["dir" => "/"],
-												   "optimize_page" => "/sample-page"
+												   "optimize_page_id" => 2
 											   ],
 											   [
 												   "query" =>  ["dir" => "/"],
-												   "optimize_page" => "/sample-page"
+												   "optimize_page_id" => 2
 											   ]
 										   ]
 		], $stub);
@@ -123,11 +123,11 @@ class LayoutOptimizerOptionTest extends WP_UnitTestCase {
 										   "contents_group" => [
 											   [
 												   "query" =>  ["dir" => "/"],
-												   "optimize_page" => "/sample-page"
+												   "optimize_page_id" => 2
 											   ],
 											   [
 												   "query" =>  ["dir" => "/"],
-												   "optimize_page" => "/sample-page"
+												   "optimize_page_id" => 2
 											   ]
 										   ]
 		], $stub);
@@ -143,11 +143,11 @@ class LayoutOptimizerOptionTest extends WP_UnitTestCase {
 										   "contents_group" => [
 											   [
 												   "query" =>  ["dir" => "/"],
-												   "optimize_page" => "/sample-page"
+												   "optimize_page" => 2
 											   ],
 											   [
 												   "query" =>  ["dir" => "/"],
-												   "optimize_page" => "/sample-page"
+												   "optimize_page_id" => 2
 											   ]
 										   ]
 		], $stub);
@@ -181,11 +181,11 @@ class LayoutOptimizerOptionTest extends WP_UnitTestCase {
 										   "contents_group" => [
 											   [
 												   "query" =>  ["dir" => "/"],
-												   "optimize_page" => "/sample-page"
+												   "optimize_page_id" => 2
 											   ],
 											   [
 												   "query" =>  ["dir" => "/"],
-												   "optimize_page" => "/sample-page"
+												   "optimize_page_id" => 2
 											   ]
 										   ]
 		], $stub);


### PR DESCRIPTION
Fixed #44
設定画面からパスを指定する欄を削除しました。
（0.0.8で互換性のために残していました）

[![Image from Gyazo](https://i.gyazo.com/9591b6adcd7571e044da8ab6a2356a45.png)](https://gyazo.com/9591b6adcd7571e044da8ab6a2356a45)