### PR TITLE
Fixed #47 取得件数が表示記事数未満だった場合、不足分について、記事をランダムに取得する。

### DIFF
--- a/classes/functions.php
+++ b/classes/functions.php
@@ -8,7 +8,7 @@ function layout_optimizer_join( $join ) {
 	if ( !layout_optimizer_is_optimize_page() ) {
 		return $join;
 	}
-	$join .= " INNER JOIN {$wpdb->prefix}googleanalytics ON $wpdb->posts.ID = wp_googleanalytics.post_id ";
+	$join .= " LEFT JOIN {$wpdb->prefix}googleanalytics ON $wpdb->posts.ID = wp_googleanalytics.post_id ";
 	return $join;
 }
 
@@ -18,9 +18,7 @@ function layout_optimizer_where( $where ) {
 		return $where;
 	}
 	$optimize_page_id = get_the_ID();
-	//var_dump($optimize_page_id);
-	//$where .= " AND wp_googleanalytics.contents_group = 0 ";
-	$where .= $wpdb->prepare(" AND {$wpdb->prefix}googleanalytics.optimize_page_id = %d ", $optimize_page_id);
+	$where .= $wpdb->prepare(" AND ({$wpdb->prefix}googleanalytics.optimize_page_id = %d OR {$wpdb->prefix}googleanalytics.optimize_page_id IS NULL) " , $optimize_page_id);
 	return $where;
 }
 
@@ -29,7 +27,7 @@ function layout_optimizer_orderby( $where ) {
 	if ( !layout_optimizer_is_optimize_page() ) {
 		return $where;
 	}
-	$where =  " {$wpdb->prefix}googleanalytics.pv DESC ";
+	$where =  " {$wpdb->prefix}googleanalytics.pv DESC,rand() ";
 	return $where;
 }
 add_filter('posts_join', 'layout_optimizer_join' );

--- a/layout-optimizer.php
+++ b/layout-optimizer.php
@@ -3,7 +3,7 @@
 	Plugin Name: LayoutOptimizer
 	Plugin URI:
 	Description: レイアウトを最適化するプラグイン
-	Version: 0.0.9
+	Version: 0.0.10
 	Author: designrule
 	Author URI: https://github.com/designrule/layout-optimizer-plugin
 	License: GPL2


### PR DESCRIPTION
Fixed #47

# 前提条件
記事の総数が指定件数 より多いのが前提

# 検討した点
order by rand()は、DBに負荷がかかるのは認識している。
- しかし、WP_Queryで'orderby'  => 'rand'を指定したときと同じなので、一旦これでいく。。。
- 後ほどpvが伸びて高負荷になったら再検討する
